### PR TITLE
Ensured authInProgress is toggled back after completion.

### DIFF
--- a/DigiMeSDK/Core/Classes/DMEAuthorizationManager.m
+++ b/DigiMeSDK/Core/Classes/DMEAuthorizationManager.m
@@ -78,6 +78,8 @@ static NSString * const kCARequestRegisteredAppID = @"CARequestRegisteredAppID";
             self.authCompletionBlock(self.session, err);
         });
     }
+    
+    self.authInProgress = NO;
 }
 
 #pragma mark - Authorization

--- a/DigiMeSDK/Core/Classes/DMEAuthorizationManager.m
+++ b/DigiMeSDK/Core/Classes/DMEAuthorizationManager.m
@@ -24,7 +24,6 @@ static NSString * const kCARequestRegisteredAppID = @"CARequestRegisteredAppID";
 
 @property (nonatomic, strong, readonly) CASession *session;
 @property (nonatomic, strong, readonly) CASessionManager *sessionManager;
-@property (nonatomic) BOOL authInProgress;
 @property (nonatomic, copy, nullable) AuthorizationCompletionBlock authCompletionBlock;
 
 @end
@@ -52,11 +51,6 @@ static NSString * const kCARequestRegisteredAppID = @"CARequestRegisteredAppID";
 
 - (void)handleAction:(DMEOpenAction *)action withParameters:(NSDictionary<NSString *,id> *)parameters
 {
-    if (!self.authInProgress)
-    {
-        return;
-    }
-    
     BOOL result = [parameters[kCADigimeResponse] boolValue];
     NSString *sessionKey = parameters[kCARequestSessionKey];
     
@@ -78,28 +72,17 @@ static NSString * const kCARequestRegisteredAppID = @"CARequestRegisteredAppID";
             self.authCompletionBlock(self.session, err);
         });
     }
-    
-    self.authInProgress = NO;
 }
 
 #pragma mark - Authorization
 
 -(void)beginAuthorizationWithCompletion:(AuthorizationCompletionBlock)completion
 {
-    if (self.authInProgress)
-    {
-        NSError *authError = [NSError authError:AuthErrorInProgress];
-        completion(self.session, authError);
-        return;
-    }
-    
     if (![self.sessionManager isSessionValid])
     {
         completion(nil, [NSError authError:AuthErrorInvalidSession]);
         return;
     }
-    
-    self.authInProgress = YES;
     self.authCompletionBlock = completion;
     
     DMEOpenAction *action = @"data";

--- a/DigiMeSDK/Core/Classes/Errors/NSError+Auth.h
+++ b/DigiMeSDK/Core/Classes/Errors/NSError+Auth.h
@@ -15,7 +15,6 @@ static NSString * const DME_AUTHORIZATION_ERROR = @"me.digi.authorization";
 typedef NS_ENUM(NSInteger, AuthError) {
     AuthErrorGeneral    = 1, //general error
     AuthErrorCancelled  = 5, //authorization cancelled
-    AuthErrorInProgress = 6, //authorization already in progress
     AuthErrorInvalidSession = 7, //invalid session
     AuthErrorInvalidSessionKey = 10, //session key returned by Digi.me app is invalid
 };

--- a/DigiMeSDK/Core/Classes/Errors/NSError+Auth.m
+++ b/DigiMeSDK/Core/Classes/Errors/NSError+Auth.m
@@ -30,10 +30,6 @@
             return @"User cancelled authorization.";
             break;
             
-        case AuthErrorInProgress:
-            return @"Authorization already in progress.";
-            break;
-            
         case AuthErrorInvalidSessionKey:
             return @"Digi.me app returned an invalid session key.";
             break;

--- a/DigiMeSDK/Core/Classes/Security/DMECrypto.m
+++ b/DigiMeSDK/Core/Classes/Security/DMECrypto.m
@@ -148,6 +148,8 @@ static const NSInteger kHashLength = 64;
     CFDataRef ref       = NULL;
     NSData*   peerTag   = [[NSData alloc] initWithBytes:(const void *)[keyTagString UTF8String] length:[keyTagString length]];
     
+    NSAssert(keyData, @"DigiMeSDK: Failed to extract key data. Did you set your P12 password?");
+    
     NSDictionary* attr = @{
                            (__bridge id)kSecClass               : (__bridge id)kSecClassKey,
                            (__bridge id)kSecAttrKeyType         : (__bridge id)kSecAttrKeyTypeRSA,


### PR DESCRIPTION
Also improved an error message, rather than crashing with an array nil object error, we now actually tell the user what's wrong.