### PR TITLE
Open URL Fix

### DIFF
--- a/DigiMeSDK/Core/Classes/DMEClient.m
+++ b/DigiMeSDK/Core/Classes/DMEClient.m
@@ -525,7 +525,7 @@
                               [NSURLQueryItem queryItemWithName:@"appid" value:self.appId]];
     
     NSURL *deeplinkingURL = components.URL;
-    [self openURL:deeplinkingURL options:@{}];
+    [[UIApplication sharedApplication] openURL:deeplinkingURL options:@{} completionHandler:nil];
 }
 
 @end


### PR DESCRIPTION
Previous method call is actually used to validate if the incoming URL can be handled by the SDK, not outgoing :)