### PR TITLE
SQF: Removed Brotli support

### DIFF
--- a/DigiMeSDK.podspec
+++ b/DigiMeSDK.podspec
@@ -7,7 +7,6 @@ Pod::Spec.new do |s|
   s.license      	= { :type => "MIT", :file => "LICENSE" }
   s.author       	= { "digi.me Ltd." => "ios@digi.me" }
   s.platform     	= :ios, "10.0"
-  s.dependency "Brotli"
   s.dependency "GZIP"
   s.swift_version = "4.2"
   s.source       	= { 

--- a/DigiMeSDK/Core/Classes/DMEDataUnpacker.m
+++ b/DigiMeSDK/Core/Classes/DMEDataUnpacker.m
@@ -46,17 +46,7 @@
     }
     
     NSString *compression = json[@"compression"];
-    if ([compression isEqualToString:@"brotli"])
-    {
-        unpackedData = [DMECompressor decompressData:unpackedData usingAlgorithm:DMECompressionAlgorithmBrotli];
-        if (!unpackedData)
-        {
-            // Decompression failed
-            [NSError setSDKError:SDKErrorInvalidData toError:error];
-            return nil;
-        }
-    }
-    else if ([compression isEqualToString:@"gzip"])
+    if ([compression isEqualToString:@"gzip"])
     {
         unpackedData = [DMECompressor decompressData:unpackedData usingAlgorithm:DMECompressionAlgorithmGZIP];
         if (!unpackedData)

--- a/DigiMeSDK/Core/Classes/Utility/DMECompressor.h
+++ b/DigiMeSDK/Core/Classes/Utility/DMECompressor.h
@@ -12,7 +12,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(NSUInteger, DMECompressionAlgorithm) {
     DMECompressionAlgorithmGZIP,
-    DMECompressionAlgorithmBrotli,
 };
 
 @interface DMECompressor : NSObject

--- a/DigiMeSDK/Core/Classes/Utility/DMECompressor.m
+++ b/DigiMeSDK/Core/Classes/Utility/DMECompressor.m
@@ -7,7 +7,6 @@
 //
 
 #import "DMECompressor.h"
-@import Brotli;
 @import GZIP;
 
 @implementation DMECompressor
@@ -18,8 +17,6 @@
     {
         case DMECompressionAlgorithmGZIP:
             return [self gzipCompressData:data];
-        case DMECompressionAlgorithmBrotli:
-            return [self brotliCompressData:data];
         default:
             [NSException raise:NSInternalInconsistencyException format:@"Algorithm type %@ doesn't exist.", @(algorithm)];
     }
@@ -31,8 +28,6 @@
     {
         case DMECompressionAlgorithmGZIP:
             return [self gzipDecompressData:data];
-        case DMECompressionAlgorithmBrotli:
-            return [self brotliDecompressData:data];
         default:
             [NSException raise:NSInternalInconsistencyException format:@"Algorithm type %@ doesn't exist.", @(algorithm)];
     }
@@ -46,16 +41,6 @@
 + (nullable NSData *)gzipDecompressData:(NSData *)data
 {
     return [data gunzippedData];
-}
-
-+ (nullable NSData *)brotliCompressData:(NSData *)data
-{
-    return [data brotliCompressed];
-}
-
-+ (nullable NSData *)brotliDecompressData:(NSData *)data
-{
-    return [data brotliDecompressed];
 }
 
 @end


### PR DESCRIPTION
CA backend will no longer support brotli compression, so removing this from our SDK.