### PR TITLE
SessionManager is now public.

### DIFF
--- a/DigiMeSDK.podspec
+++ b/DigiMeSDK.podspec
@@ -27,7 +27,6 @@ Pod::Spec.new do |s|
     'DigiMeSDK/Core/Classes/Security/DMECrypto.h',
     'DigiMeSDK/Core/Classes/Security/DMEDataDecryptor.h',
     'DigiMeSDK/Core/Classes/Utility/*.h',
-    'DigiMeSDK/Core/Classes/DMESessionManager.h',
     'DigiMeSDK/Core/Classes/DMEAPIClient+Private.h',
     'DigiMeSDK/Core/Classes/DMEAppCommunicator+Private.h',
     'DigiMeSDK/Core/Classes/DMENativeConsentManager.h',


### PR DESCRIPTION
This was accidentally private, despite being an exposed property on `DMEClient`