### PR TITLE
Ongoing Access uses 'authorize' action, which is only ever returned by…

### DIFF
--- a/DigiMeSDK/Core/Classes/DMENativeConsentManager.m
+++ b/DigiMeSDK/Core/Classes/DMENativeConsentManager.m
@@ -42,7 +42,7 @@
 
 - (BOOL)canHandleAction:(DMEOpenAction *)action
 {
-    return [action isEqualToString:@"data"];
+    return [action isEqualToString:@"data"] || [action isEqualToString:@"authorize"];
 }
 
 - (void)handleAction:(DMEOpenAction *)action withParameters:(NSDictionary<NSString *,id> *)parameters


### PR DESCRIPTION
… digi.me app in case of an error, otherwise it uses 'data'