### PR TITLE
Bump all endpoints to v1.4

### DIFF
--- a/DigiMeSDK.podspec
+++ b/DigiMeSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
     s.name         	= "DigiMeSDK"
-    s.version      	= "3.2.0"
+    s.version      	= "3.3.0"
     s.summary      	= "digi.me iOS Consent Access SDK"
     s.homepage     	= "https://github.com/digime/digime-sdk-ios"
     s.license      	= { :type => "MIT", :file => "LICENSE" }

--- a/DigiMeSDK/Core/Classes/Network/DMERequestFactory.m
+++ b/DigiMeSDK/Core/Classes/Network/DMERequestFactory.m
@@ -13,8 +13,8 @@
 #import <DigiMeSDK/DigiMeSDK-Swift.h>
 
 static NSString * const kDigiMeAPIVersion = @"v1.4";
-static NSString * const kDigiMeOAuthAPIVersion = @"v1";
-static NSString * const kDigiMeJWKSAPIVersion = @"v1";
+static NSString * const kDigiMeOAuthAPIVersion = @"v1.4";
+static NSString * const kDigiMeJWKSAPIVersion = @"v1.4";
 
 @interface DMERequestFactory()
 


### PR DESCRIPTION
Backend will mandate a minimum API version of 1.4 for all endpoints in an upcoming release.