### PR TITLE
SDK-5 SDK-8 Add API client and helpers for JWT and OAuth

### DIFF
--- a/Examples/DigiMeSDKExample/.swiftlint.yml
+++ b/Examples/DigiMeSDKExample/.swiftlint.yml
@@ -229,10 +229,11 @@ cyclomatic_complexity:
   ignores_case_statements: false
 
 file_header:
+  severity: error
   required_pattern: |
                     \/\/
                     \/\/  SWIFTLINT_CURRENT_FILENAME
-                    \/\/  \DigiMeSDK|DigiMeSDKExample\
+                    \/\/  DigiMeSDK(Example)?
                     \/\/
                     \/\/  Created on \d{1,2}\/\d{1,2}\/\d{4}\.
                     \/\/  Copyright © \d{4}(\s?-\s?\d{4})? digi\.me( Limited)?\. All rights reserved\.

--- a/Examples/DigiMeSDKExample/DigiMeSDKExample.xcodeproj/xcshareddata/xcschemes/DigiMeSDKExample.xcscheme
+++ b/Examples/DigiMeSDKExample/DigiMeSDKExample.xcodeproj/xcshareddata/xcschemes/DigiMeSDKExample.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "27D31A1F266A4EAB00DB2524"
+               BuildableName = "DigiMeSDKExample.app"
+               BlueprintName = "DigiMeSDKExample"
+               ReferencedContainer = "container:DigiMeSDKExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B119B412BE17AF1A33D7B0D79AC5EDF0"
+            BuildableName = "DigiMeSDK.framework"
+            BlueprintName = "DigiMeSDK"
+            ReferencedContainer = "container:Pods/DigiMeSDK.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES"
+            testExecutionOrdering = "random">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "27D31A35266A4EAD00DB2524"
+               BuildableName = "DigiMeSDKExampleTests.xctest"
+               BlueprintName = "DigiMeSDKExampleTests"
+               ReferencedContainer = "container:DigiMeSDKExample.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "27D31A1F266A4EAB00DB2524"
+            BuildableName = "DigiMeSDKExample.app"
+            BlueprintName = "DigiMeSDKExample"
+            ReferencedContainer = "container:DigiMeSDKExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "27D31A1F266A4EAB00DB2524"
+            BuildableName = "DigiMeSDKExample.app"
+            BlueprintName = "DigiMeSDKExample"
+            ReferencedContainer = "container:DigiMeSDKExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/DigiMeSDKExample/DigiMeSDKExample/SceneDelegate.swift
+++ b/Examples/DigiMeSDKExample/DigiMeSDKExample/SceneDelegate.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2021 digi.me Limited. All rights reserved.
 //
 
+import DigiMeSDK
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
@@ -47,5 +48,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Called as the scene transitions from the foreground to the background.
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
+    }
+    
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        guard let context = URLContexts.first else {
+            return
+        }
+        
+        CallbackService.shared().handleCallback(url: context.url)
     }
 }

--- a/Source/Authorization/ConsentManager.swift
+++ b/Source/Authorization/ConsentManager.swift
@@ -114,10 +114,10 @@ class ConsentManager: NSObject {
         return .success(response)
     }
     
-    private func processErrorCallback(parameters: [String: String?]) -> AuthError {
+    private func processErrorCallback(parameters: [String: String?]) -> ConsentError {
         guard
             let code = parameters[ResponseKey.code.rawValue] as? String,
-            let error = AuthError(rawValue: code) else {
+            let error = ConsentError(rawValue: code) else {
             return .unexpectedError
         }
         
@@ -169,7 +169,7 @@ extension ConsentManager: SFSafariViewControllerDelegate {
             return
         }
         
-        finish(with: .failure(AuthError.userCancelled))
+        finish(with: .failure(ConsentError.userCancelled))
     }
 }
 
@@ -179,6 +179,6 @@ extension ConsentManager: UIAdaptivePresentationControllerDelegate {
             return
         }
         
-        finish(with: .failure(AuthError.userCancelled))
+        finish(with: .failure(ConsentError.userCancelled))
     }
 }

--- a/Source/Authorization/ConsentManager.swift
+++ b/Source/Authorization/ConsentManager.swift
@@ -1,0 +1,193 @@
+//
+//  ConsentManager.swift
+//  DigiMeSDK
+//
+//  Created on 11/06/2021.
+//  Copyright © 2021 digi.me Limited. All rights reserved.
+//
+
+import Foundation
+import SafariServices
+
+enum CallbackError: Error {
+    case unexpectedCallbackAction
+    case invalidCallbackParameters
+}
+
+struct AuthResponse {
+    struct WriteInfo {
+        let postboxId: String
+        let publicKey: String
+    }
+    
+    let authorizationCode: String
+    let status: String
+    let writeInfo: WriteInfo? // For write request authorization only
+    
+    init(code: String, status: String, writeInfo: WriteInfo? = nil) {
+        self.authorizationCode = code
+        self.status = status
+        self.writeInfo = writeInfo
+    }
+}
+
+class ConsentManager: NSObject {
+    private let configuration: Configuration
+    private var userConsentCompletion: ((Result<AuthResponse, Error>) -> Void)?
+    private var safariViewController: SFSafariViewController?
+    
+    private enum ResponseKey: String {
+        case state
+        case code
+        case postboxId
+        case publicKey
+    }
+
+    init(configuration: Configuration) {
+        self.configuration = configuration
+    }
+    
+    func requestUserConsent(preAuthCode: String, serviceId: Int?, completion: @escaping ((Result<AuthResponse, Error>) -> Void)) {
+        guard Thread.current.isMainThread else {
+            DispatchQueue.main.async {
+                self.requestUserConsent(preAuthCode: preAuthCode, serviceId: serviceId, completion: completion)
+            }
+            return
+        }
+        
+        userConsentCompletion = completion
+        CallbackService.shared().setCallbackHandler(self)
+        var components = URLComponents(string: "https://api.development.devdigi.me/apps/saas/authorize")!
+        
+        var percentEncodedQueryItems = [
+            URLQueryItem(name: "code", value: preAuthCode),
+            URLQueryItem(name: "errorCallback", value: "\(self.configuration.redirectUri)error".addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)),
+            URLQueryItem(name: "successCallback", value: "\(self.configuration.redirectUri)auth".addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)),
+        ]
+        
+        if let serviceId = serviceId {
+            percentEncodedQueryItems.append(URLQueryItem(name: "service", value: "\(serviceId)"))
+        }
+        
+        components.percentEncodedQueryItems = percentEncodedQueryItems
+        let url = components.url!
+        let viewController = SFSafariViewController(url: url)
+        viewController.delegate = self
+        viewController.presentationController?.delegate = self
+        viewController.dismissButtonStyle = .cancel
+        safariViewController = viewController
+        
+        UIViewController.topMostViewController()?.present(viewController, animated: true, completion: nil)
+    }
+    
+    private func finish(with result: Result<AuthResponse, Error>) {
+        guard Thread.current.isMainThread else {
+            DispatchQueue.main.async {
+                self.finish(with: result)
+            }
+            return
+        }
+        
+        safariViewController?.delegate = nil
+        safariViewController?.presentationController?.delegate = nil
+        safariViewController = nil
+        
+        userConsentCompletion?(result)
+        userConsentCompletion = nil
+    }
+    
+    private func processSuccessCallback(parameters: [String: String?]) -> Result<AuthResponse, Error> {
+        guard
+            let status = parameters[ResponseKey.state.rawValue] as? String,
+            let code = parameters[ResponseKey.code.rawValue] as? String else {
+            return .failure(CallbackError.invalidCallbackParameters)
+        }
+        
+        var writeInfo: AuthResponse.WriteInfo?
+        if
+            let postboxId = parameters[ResponseKey.postboxId.rawValue] as? String,
+            let publicKey = parameters[ResponseKey.publicKey.rawValue] as? String {
+            writeInfo = .init(postboxId: postboxId, publicKey: publicKey)
+        }
+
+        let response = AuthResponse(code: code, status: status, writeInfo: writeInfo)
+        return .success(response)
+    }
+    
+    private func processErrorCallback(parameters: [String: String?]) -> AuthError {
+        guard
+            let code = parameters[ResponseKey.code.rawValue] as? String,
+            let error = AuthError(rawValue: code) else {
+            return .unexpectedError
+        }
+        
+        return error
+    }
+}
+
+extension ConsentManager: CallbackHandler {
+    func canHandleAction(_ action: String) -> Bool {
+        action == "auth" || action == "error"
+    }
+    
+    func handleAction(_ action: String, with parameters: [String: String?]) {
+        CallbackService.shared().removeCallbackHandler(self)
+        
+        // User could have opened in Safari Browser and cancelled/completed authentication in SafariViewController
+        // then cancelled/completed authentication again in Browser,
+        // in which case we ignore any callback from Browser as app has already handled a callback.
+        guard
+            let viewController = safariViewController,
+            viewController.isViewLoaded,
+            viewController.view.window != nil,
+            let presentingViewController = viewController.presentingViewController else {
+            return
+        }
+        
+        let result: Result<AuthResponse, Error>!
+        switch action {
+        case "auth":
+            result = processSuccessCallback(parameters: parameters)
+            
+        case "error":
+            let error = processErrorCallback(parameters: parameters)
+            result = .failure(error)
+            
+        default:
+            result = .failure(CallbackError.unexpectedCallbackAction)
+        }
+        
+        presentingViewController.dismiss(animated: true) {
+            self.finish(with: result)
+        }
+    }
+}
+
+extension ConsentManager: SFSafariViewControllerDelegate {
+    func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
+        guard controller === safariViewController else {
+            return
+        }
+        
+        finish(with: .failure(AuthError.userCancelled))
+    }
+    
+    @available(iOS 14.0, *)
+    func safariViewControllerWillOpenInBrowser(_ controller: SFSafariViewController) {
+        guard controller === safariViewController else {
+            return
+        }
+        
+        
+    }
+}
+
+extension ConsentManager: UIAdaptivePresentationControllerDelegate {
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        guard presentationController.presentedViewController === safariViewController else {
+            return
+        }
+        
+        finish(with: .failure(AuthError.userCancelled))
+    }
+}

--- a/Source/Authorization/ConsentManager.swift
+++ b/Source/Authorization/ConsentManager.swift
@@ -171,15 +171,6 @@ extension ConsentManager: SFSafariViewControllerDelegate {
         
         finish(with: .failure(AuthError.userCancelled))
     }
-    
-    @available(iOS 14.0, *)
-    func safariViewControllerWillOpenInBrowser(_ controller: SFSafariViewController) {
-        guard controller === safariViewController else {
-            return
-        }
-        
-        
-    }
 }
 
 extension ConsentManager: UIAdaptivePresentationControllerDelegate {

--- a/Source/Authorization/JSONWebKey.swift
+++ b/Source/Authorization/JSONWebKey.swift
@@ -1,0 +1,17 @@
+//
+//  JSONWebKey.swift
+//  DigiMeSDK
+//
+//  Created on 08/06/2021.
+//  Copyright © 2021 digi.me Limited. All rights reserved.
+//
+
+import Foundation
+
+struct JSONWebKey: Decodable {
+    let e: String // RSA public exponent
+    let kid: String // Key identifier
+    let kty: String // Key type identifies the cryptographic algorithm family used with the key, such as 'RSA' or 'EC'
+    let n: String // RSA Modulus
+    let pem: String // PCKS1 public pem encoded publkic key representation
+}

--- a/Source/Authorization/JSONWebKeySet.swift
+++ b/Source/Authorization/JSONWebKeySet.swift
@@ -1,0 +1,19 @@
+//
+//  JSONWebKeySet.swift
+//  DigiMeSDK
+//
+//  Created on 08/06/2021.
+//  Copyright © 2021 digi.me Limited. All rights reserved.
+//
+
+import Foundation
+
+struct JSONWebKeySet: Decodable {
+    let keys: [JSONWebKey]
+    let date = Date()
+    
+    // Cache for 15 minutes
+    var isValid: Bool {
+        Date() < date.addingTimeInterval(15 * 60)
+    }
+}

--- a/Source/Authorization/JWTUtility.swift
+++ b/Source/Authorization/JWTUtility.swift
@@ -1,0 +1,525 @@
+//
+//  JWTUtility.swift
+//  DigiMeSDK
+//
+//  Created on 04/12/2019.
+//  Copyright © 2019 digi.me Limited. All rights reserved.
+//
+
+import CryptoKit
+import Foundation
+import SwiftJWT
+
+class JWTUtility: NSObject {
+   
+    // Default JWT header
+    class var header: Header {
+        Header(typ: "JWT")
+    }
+
+    // claims to request a pre-authorization code
+    struct PayloadRequestPreauthJWT: Claims {
+        let clientId: String
+        let codeChallenge: String
+        let codeChallengeMethod = "S256"
+        let nonce = JWTUtility.generateNonce()
+        let redirectUri: String
+        let responseMode = "query"
+        let responseType = "code"
+        let state = JWTUtility.secureRandomHexString(length: 32)
+        let timestamp = Date()
+        
+        init(clientId: String, codeChallenge: String, redirectUri: String) {
+            self.clientId = clientId
+            self.codeChallenge = codeChallenge
+            self.redirectUri = redirectUri
+        }
+        
+        func encode() throws -> String {
+            let jsonEncoder = JSONEncoder()
+            jsonEncoder.dateEncodingStrategy = .millisecondsSince1970
+            jsonEncoder.keyEncodingStrategy = .convertToSnakeCase
+            let data = try jsonEncoder.encode(self)
+            return JWTEncoder.base64urlEncodedString(data: data)
+        }
+    }
+    
+    // claims to validate pre-authorization code
+    class PayloadValidatePreauthJWT: NSObject, Claims {
+        var preAuthCode: String?
+
+        enum CodingKeys: String, CodingKey {
+            case preAuthCode = "preauthorization_code"
+        }
+    }
+    
+    // claims to request a authorization code
+    class PayloadRequestAuthJWT: NSObject, Claims {
+        var clientId: String?
+        var code: String?
+        var codeVerifier: String?
+        var grantType: String?
+        var nonce: String?
+        var redirectUrl: String?
+        var timestamp: Double?
+
+        enum CodingKeys: String, CodingKey {
+            case clientId = "client_id"
+            case code
+            case codeVerifier = "code_verifier"
+            case grantType = "grant_type"
+            case nonce
+            case redirectUrl = "redirect_uri"
+            case timestamp
+        }
+    }
+    
+    // claims to validate authorization and refresh tokens
+    class PayloadValidateAuthJWT: NSObject, Claims {
+        var accessToken: String?
+        var expiresTimestamp: Double?
+        var refreshToken: String?
+        var tokenType: String?
+        
+        enum CodingKeys: String, CodingKey {
+            case accessToken = "access_token"
+            case expiresTimestamp = "expires_on"
+            case refreshToken = "refresh_token"
+            case tokenType = "token_type"
+        }
+    }
+    
+    // claims to request data trigger
+    class PayloadDataTriggerJWT: NSObject, Claims {
+        var accessToken: String?
+        var clientId: String?
+        var nonce: String?
+        var redirectUrl: String?
+        var sessionKey: String?
+        var timestamp: Double?
+
+        enum CodingKeys: String, CodingKey {
+            case accessToken = "access_token"
+            case clientId = "client_id"
+            case nonce
+            case redirectUrl = "redirect_uri"
+            case sessionKey = "session_key"
+            case timestamp
+        }
+    }
+    
+    // claims to request OAuth token renewal
+    class PayloadRefreshOAuthJWT: NSObject, Claims {
+        var clientId: String?
+        var grantType: String?
+        var nonce: String?
+        var redirectUrl: String?
+        var refreshToken: String?
+        var timestamp: Double?
+        
+        enum CodingKeys: String, CodingKey {
+            case clientId = "client_id"
+            case grantType = "grant_type"
+            case nonce
+            case redirectUrl = "redirect_uri"
+            case refreshToken = "refresh_token"
+            case timestamp
+        }
+    }
+    
+    class PayloadPostboxPush: NSObject, Claims {
+        var accessToken: String?
+        var clientId: String?
+        var iv: String?
+        var metadata: String?
+        var nonce: String?
+        var redirectUrl: String?
+        var sessionKey: String?
+        var symmetricalKey: String?
+        var timestamp: Double?
+        
+        enum CodingKeys: String, CodingKey {
+            case accessToken = "access_token"
+            case clientId = "client_id"
+            case iv
+            case metadata
+            case nonce
+            case redirectUrl = "redirect_uri"
+            case sessionKey = "session_key"
+            case symmetricalKey = "symmetrical_key"
+            case timestamp
+        }
+    }
+
+    /// Creates request JWT which can be used to get a preAuthentication token
+    ///
+    /// - Parameters:
+    ///   - appId: application identifier
+    ///   - contractId: contract identifier
+    ///   - privateKey: private key in base 64 format
+    ///   - publicKey: public key in base 64 format
+    class func signedPreAuthJwt(_ appId: String, contractId: String, privateKey: String, publicKey: String?) -> String? {
+        guard
+            privateKey.isBase64(),
+            let privateKeyData = convertKeyString(privateKey) else {
+                print("DigiMeSDK: Error creating RSA key")
+                return nil
+        }
+        
+        let randomBytes = secureRandomData(length: 32)
+        let codeVerifier = randomBytes.base64URLEncodedString()
+        let codeChallenge = Data(SHA256.hash(data: codeVerifier.data(using: .utf8)!)).base64URLEncodedString()
+        saveCodeVerifier(codeVerifier)
+        
+        let claims = PayloadRequestPreauthJWT(
+            clientId: "\(appId)_\(contractId)",
+            codeChallenge: codeChallenge,
+            
+            // NB! this redirect schema must exist in the contract definition, otherwise preauth request will fail!
+            redirectUri: "digime-ca-\(appId)"
+        )
+
+        // signing
+        var jwt = JWT(header: header, claims: claims)
+        let signer = JWTSigner.ps512(privateKey: privateKeyData)
+        guard let signedJwt = try? jwt.sign(using: signer) else {
+            print("DigiMeSDK: Error signing preAuth JWT")
+            return nil
+        }
+
+        // validation
+        guard
+            let publicKeyBase64 = publicKey,
+            let publicKey = convertKeyString(publicKeyBase64) else {
+                return signedJwt
+        }
+        
+        let verifier = JWTVerifier.ps512(publicKey: publicKey)
+        let isVerified = JWT<PayloadRequestPreauthJWT>.verify(signedJwt, using: verifier)
+
+        return isVerified ? signedJwt : nil
+    }
+    
+    /// Creates request JWT which can be used to get an authentication token
+    /// - Parameters:
+    ///   - authCode: OAuth authorization code
+    ///   - appId: application identifier
+    ///   - contractId: contract identifier
+    ///   - privateKey: private key in base 64 format
+    ///   - publicKey: public key in base 64 format
+    class func signedAuthJwt(_ authCode: String, appId: String, contractId: String, privateKey: String, publicKey: String?) -> String? {
+        guard
+            privateKey.isBase64(),
+            let privateKeyData = convertKeyString(privateKey) else {
+                print("DigiMeSDK: Error creating RSA key")
+                return nil
+        }
+
+        let claims = PayloadRequestAuthJWT()
+        claims.clientId = "\(appId)_\(contractId)"
+        claims.code = authCode
+        claims.codeVerifier = retrieveCodeVerifier()
+        claims.grantType = "authorization_code"
+        claims.nonce = generateNonce()
+        
+        // NB! this redirect schema must exist in the CA contract definition, otherwise preauth request will fail!
+        claims.redirectUrl = "digime-ca-\(appId)"
+        claims.timestamp = NSDate().timeIntervalSince1970 * 1000.0
+
+        // signing
+        var jwt = JWT(header: header, claims: claims)
+        let signer = JWTSigner.ps512(privateKey: privateKeyData)
+        guard let signedJwt = try? jwt.sign(using: signer) else {
+            print("DigiMeSDK: Error signing auth JWT")
+            return nil
+        }
+
+        // validation
+        guard
+            let publicKeyBase64 = publicKey,
+            let publicKey = convertKeyString(publicKeyBase64) else {
+                return signedJwt
+        }
+        
+        let verifier = JWTVerifier.ps512(publicKey: publicKey)
+        let isVerified = JWT<PayloadRequestAuthJWT>.verify(signedJwt, using: verifier)
+
+        return isVerified ? signedJwt : nil
+    }
+    
+    /// Extracts preAuthorization code from JWT
+    /// - Parameters:
+    ///   - publicKey: public key in base 64 format
+    ///   - jwt: pre-authorization code wrapped in JWT
+    class func preAuthCode(from jwt: String, publicKey: String) -> String? {
+        guard
+            publicKey.isBase64(),
+            let publicKeyData = convertKeyString(publicKey) else {
+                print("DigiMeSDK: Error creating RSA public key")
+                return nil
+        }
+        
+        // validation
+        let verifier = JWTVerifier.ps512(publicKey: publicKeyData)
+        let isVerified = JWT<PayloadValidatePreauthJWT>.verify(jwt, using: verifier)
+        
+        guard isVerified else {
+            return nil
+        }
+        
+        let decoder = JWTDecoder(jwtVerifier: verifier)
+        let decodedJwt = try? decoder.decode(JWT<PayloadValidatePreauthJWT>.self, fromString: jwt)
+        guard let preauthCode = decodedJwt?.claims.preAuthCode else {
+            return nil
+        }
+        return preauthCode
+    }
+    
+    /// Extracts access and refresh tokens from JWT, and wraps in `DMEOAuthToken`.
+    /// - Parameters
+    ///  - jwt: JSON Web Token containing access/refresh token pair.
+    ///  - publicKey: public key in base 64 format
+    class func oAuthToken(from jwt: String, publicKey: String) -> OAuthToken? {
+        guard let publicKeyData = convertKeyString(publicKey) else {
+                print("DigiMeSDK: Error creating RSA public key")
+                return nil
+        }
+        
+        // validation
+        let verifier = JWTVerifier.ps512(publicKey: publicKeyData)
+        let isVerified = JWT<PayloadValidateAuthJWT>.verify(jwt, using: verifier)
+        
+        guard isVerified else {
+            return nil
+        }
+        
+        let decoder = JWTDecoder(jwtVerifier: verifier)
+        let jwt = try? decoder.decode(JWT<PayloadValidateAuthJWT>.self, fromString: jwt)
+        guard
+            let accessToken = jwt?.claims.accessToken,
+            let refreshToken = jwt?.claims.refreshToken,
+            let expiresTimestamp = jwt?.claims.expiresTimestamp else {
+            return nil
+        }
+        
+        return OAuthToken(
+            accessToken: accessToken,
+            refreshToken: refreshToken,
+            expiry: Date(timeIntervalSince1970: expiresTimestamp),
+            tokenType: jwt?.claims.tokenType
+        )
+    }
+    
+    /// Creates request JWT which can be used to trigger data
+    /// - Parameters:
+    ///   - accessToken: OAuth access token
+    ///   - appId: application identifier
+    ///   - contractId: contract identifier
+    ///   - sessionKey: session key
+    ///   - privateKey: private key in base 64 format
+    ///   - publicKey: public key in base 64 format
+    class func dataTriggerJwt(_ accessToken: String, appId: String, contractId: String, sessionKey: String, privateKey: String, publicKey: String?) -> String? {
+        guard
+            privateKey.isBase64(),
+            let privateKeyData = convertKeyString(privateKey) else {
+                print("DigiMeSDK: Error creating RSA key")
+                return nil
+        }
+        
+        let claims = PayloadDataTriggerJWT()
+        claims.accessToken = accessToken
+        claims.clientId = "\(appId)_\(contractId)"
+        claims.nonce = generateNonce()
+        
+        // NB! this redirect schema must exist in the CA contract definition, otherwise this request will fail!
+        claims.redirectUrl = "digime-ca-\(appId)"
+        claims.sessionKey = sessionKey
+        claims.timestamp = NSDate().timeIntervalSince1970 * 1000.0
+
+        // signing
+        var jwt = JWT(header: header, claims: claims)
+        let signer = JWTSigner.ps512(privateKey: privateKeyData)
+        guard let signedJwt = try? jwt.sign(using: signer) else {
+            print("DigiMeSDK: Error signing data trigger JWT")
+            return nil
+        }
+
+        // validation
+        guard
+            let publicKeyBase64 = publicKey,
+            let publicKeyData = convertKeyString(publicKeyBase64) else {
+                return signedJwt
+        }
+        
+        let verifier = JWTVerifier.ps512(publicKey: publicKeyData)
+        let isVerified = JWT<PayloadDataTriggerJWT>.verify(signedJwt, using: verifier)
+
+        return isVerified ? signedJwt : nil
+    }
+    
+    class func refreshJwt(from refreshToken: String, appId: String, contractId: String, privateKey: String, publicKey: String?) -> String? {
+        guard
+            privateKey.isBase64(),
+            let privateKeyData = convertKeyString(privateKey) else {
+                print("DigiMeSDK: Error creating RSA key")
+                return nil
+        }
+        
+        let claims = PayloadRefreshOAuthJWT()
+        claims.clientId = "\(appId)_\(contractId)"
+        claims.grantType = "refresh_token"
+        claims.nonce = generateNonce()
+        
+        // NB! this redirect schema must exist in the CA contract definition, otherwise preauth request will fail!
+        claims.redirectUrl = "digime-ca-\(appId)"
+        claims.refreshToken = refreshToken
+        claims.timestamp = NSDate().timeIntervalSince1970 * 1000.0
+
+        // signing
+        var jwt = JWT(header: header, claims: claims)
+        let signer = JWTSigner.ps512(privateKey: privateKeyData)
+        guard let signedJwt = try? jwt.sign(using: signer) else {
+            print("DigiMeSDK: Error signing our test token")
+            return nil
+        }
+
+        // validation
+        guard
+            let publicKeyBase64 = publicKey,
+            let publicKeyData = convertKeyString(publicKeyBase64) else {
+                return signedJwt
+        }
+        
+        let verifier = JWTVerifier.ps512(publicKey: publicKeyData)
+        let isVerified = JWT<PayloadRefreshOAuthJWT>.verify(signedJwt, using: verifier)
+
+        return isVerified ? signedJwt : nil
+    }
+    
+//    class func postboxPushJwt(from accessToken: String?, appId: String, contractId: String, iv: String, metadata: String, sessionKey: String, symmetricalKey: String, privateKey: String, publicKey: String?) -> String? {
+//        guard
+//            privateKey.isBase64(),
+//            let privateKeyData = convertKeyString(privateKey) else {
+//                print("DigiMeSDK: Error creating RSA key")
+//                return nil
+//        }
+//
+//        let claims = PayloadPostboxPush()
+//        claims.accessToken = accessToken
+//        claims.clientId = "\(appId)_\(contractId)"
+//        claims.iv = iv
+//        claims.metadata = metadata.replacingOccurrences(of: "[\\n\\r]", with: "", options: .regularExpression, range: nil)
+//        claims.nonce = generateNonce()
+//
+//        // NB! this redirect schema must exist in the CA contract definition, otherwise preauth request will fail!
+//        claims.redirectUrl = "digime-ca-\(appId)"
+//        claims.sessionKey = sessionKey
+//        claims.symmetricalKey = symmetricalKey.replacingOccurrences(of: "[\\n\\r]", with: "", options: .regularExpression, range: nil)
+//        claims.timestamp = NSDate().timeIntervalSince1970 * 1000.0
+//
+//        // signing
+//        var jwt = JWT(header: header, claims: claims)
+//        let signer = JWTSigner.ps512(privateKey: privateKeyData)
+//        guard let signedJwt = try? jwt.sign(using: signer) else {
+//            print("DigiMeSDK: Error signing our test token")
+//            return nil
+//        }
+//
+//        // validation
+//        guard
+//            let publicKeyBase64 = publicKey,
+//            let publicKeyData = convertKeyString(publicKeyBase64) else {
+//                return signedJwt
+//        }
+//
+//        let verifier = JWTVerifier.ps512(publicKey: publicKeyData)
+//        let isVerified = JWT<PayloadRefreshOAuthJWT>.verify(signedJwt, using: verifier)
+//
+//        return isVerified ? signedJwt : nil
+//    }
+    
+    // MARK: - Utility functions
+    
+    private class func generateNonce() -> String {
+        secureRandomHexString(length: 16)
+    }
+    
+    private class func secureRandomHexString(length: Int) -> String {
+        secureRandomBytes(length: length)
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+    
+    private class func secureRandomData(length: Int) -> Data {
+        Data(bytes: secureRandomBytes(length: length))
+    }
+    
+    private class func secureRandomBytes(length: Int) -> [UInt8] {
+        var bytes = [UInt8](repeating: 0, count: length)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        if status != errSecSuccess {
+            NSLog("Error generating secure random bytes. Status: \(status)")
+        }
+        
+        return bytes
+    }
+    
+    private class func convertKeyString(_ keyString: String) -> Data? {
+        guard let base64String = base64String(for: keyString) else {
+            print("Couldn't read a key string")
+            return nil
+        }
+
+        return convertKeyBase64ToData(base64String)
+    }
+    
+    private class func convertKeyBase64ToData(_ base64KeyString: String) -> Data? {
+        guard let publicKeyData = Data(base64Encoded: base64KeyString, options: [.ignoreUnknownCharacters]) else {
+            print("Couldn't decode base64 key")
+            return nil
+        }
+
+        return publicKeyData
+    }
+    
+    ///
+    /// Get the Base64 representation of a PEM encoded string after stripping off the PEM markers.
+    ///
+    /// - Parameters:
+    ///        - pemString:        `String` containing PEM formatted data.
+    ///
+    /// - Returns:                Base64 encoded `String` containing the data.
+    ///
+    private class func base64String(for pemString: String) -> String? {
+        
+        // Filter looking for new lines...
+        var lines = pemString
+            .components(separatedBy: "\n")
+            .filter { !$0.hasPrefix("-----BEGIN") && !$0.hasPrefix("-----END") }
+        
+        // No lines, no data...
+        guard !lines.isEmpty else {
+            return nil
+        }
+        
+        return lines
+            .map { $0.replacingOccurrences(of: "\r", with: "") }
+            .joined()
+    }
+}
+
+// MARK: - Utility extensions
+
+extension JWTUtility {
+    static let codeVerifier: String = "me.digi.sdk.codeVerifier"
+    
+    // save code verifier for OAuth session
+    class func saveCodeVerifier(_ codeVerifier: String) {
+        let defaults = UserDefaults.standard
+        defaults.set(codeVerifier, forKey: JWTUtility.codeVerifier)
+    }
+    
+    class func retrieveCodeVerifier() -> String? {
+        return UserDefaults.standard.object(forKey: JWTUtility.codeVerifier) as? String
+    }
+}

--- a/Source/Authorization/JWTUtility.swift
+++ b/Source/Authorization/JWTUtility.swift
@@ -174,7 +174,7 @@ class JWTUtility: NSObject {
             codeChallenge: codeChallenge,
             
             // NB! this redirect schema must exist in the contract definition, otherwise preauth request will fail!
-            redirectUri: configuration.redirectUri
+            redirectUri: configuration.redirectUri + "auth"
         )
 
         // signing

--- a/Source/Authorization/OAuthService.swift
+++ b/Source/Authorization/OAuthService.swift
@@ -1,0 +1,28 @@
+//
+//  OAuthService.swift
+//  DigiMeSDK
+//
+//  Created on 08/06/2021.
+//  Copyright © 2021 digi.me Limited. All rights reserved.
+//
+
+import Foundation
+
+class OAuthService {
+    
+    private let configuration: Configuration
+    private let apiClient: APIClient
+    
+    init(configuration: Configuration, apiClient: APIClient) {
+        self.configuration = configuration
+        self.apiClient = apiClient
+    }
+    
+    func requestPreAuthorizationCode(publicKey: String?, completion: (Result<String, Error>) -> Void) {
+        
+    }
+    
+    func requestTokenExchange(authCode: String, publicKey: String?, completion: (Result<String, Error>) -> Void) {
+        
+    }
+}

--- a/Source/Authorization/OAuthService.swift
+++ b/Source/Authorization/OAuthService.swift
@@ -13,16 +13,82 @@ class OAuthService {
     private let configuration: Configuration
     private let apiClient: APIClient
     
+    private var jwks: JSONWebKeySet?
+    
     init(configuration: Configuration, apiClient: APIClient) {
         self.configuration = configuration
         self.apiClient = apiClient
     }
     
-    func requestPreAuthorizationCode(publicKey: String?, completion: (Result<String, Error>) -> Void) {
-        
+    struct Session: Decodable {
+        let expiry: Double
+        let key: String
     }
     
-    func requestTokenExchange(authCode: String, publicKey: String?, completion: (Result<String, Error>) -> Void) {
+    struct PreAuthResponse: Decodable {
+        let token: String
+        let session: Session
+    }
+    
+    func requestPreAuthorizationCode(publicKey: String?, completion: @escaping (Result<String, Error>) -> Void) {
+        guard let jwt = JWTUtility.preAuthorizationRequestJWT(configuration: configuration) else {
+            fatalError("Invalid pre-authorization request JWT")
+        }
+
+        apiClient.makeRequest(.authorize(jwt: jwt, agent: apiClient.agent, readOptions: readOptions)) { [weak self] (result: Result<PreAuthResponse, Error>) in
+            switch result {
+            case .success(let response):
+                self?.extractPeAuthorizationCode(from: response) { result in
+                    completion(result.map { PreAuthResponse(token: $0, session: response.session) })
+                }
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+    
+    private func extractPeAuthorizationCode(from response: PreAuthResponse, completion: @escaping (Result<String, Error>) -> Void) {
+        latestJsonWebKeySet { result in
+            let newResult = result.flatMap { JWTUtility.preAuthCode(from: response.token, keySet: $0) }
+            completion(newResult)
+        }
+    }
+    
+    func requestTokenExchange(authCode: String, publicKey: String?, completion: (Result<PreAuthResponse, Error>) -> Void) {
+    }
+    
+    private func latestJsonWebKeySet(completion: @escaping (Result<JSONWebKeySet, Error>) -> Void) {
+        if
+            let jwks = jwks,
+            jwks.isValid {
+            completion(.success(jwks))
+            return
+        }
         
+        apiClient.makeRequest(.jwks) { (result: Result<JSONWebKeySet, Error>) in
+            if let jwks = try? result.get() {
+                self.jwks = jwks
+            }
+            
+            completion(result)
+        }
+    }
+}
+
+struct JSONWebKey: Decodable {
+    let e: String // RSA public exponent
+    let kid: String // Key identifier
+    let kty: String // Key type identifies the cryptographic algorithm family used with the key, such as 'RSA' or 'EC'
+    let n: String // RSA Modulus
+    let pem: String // PCKS1 public pem encoded publkic key representation
+}
+
+struct JSONWebKeySet: Decodable {
+    let keys: [JSONWebKey]
+    let date = Date()
+    
+    // Cache for 15 minutes
+    var isValid: Bool {
+        Date() < date.addingTimeInterval(15*60)
     }
 }

--- a/Source/Authorization/OAuthService.swift
+++ b/Source/Authorization/OAuthService.swift
@@ -25,12 +25,14 @@ class OAuthService {
         let key: String
     }
     
+    // Can be used for raw response from server where `token` is the JWT
+    // and as result when `token` is the extracted pre-authrozation code
     struct PreAuthResponse: Decodable {
         let token: String
         let session: Session
     }
     
-    func requestPreAuthorizationCode(publicKey: String?, completion: @escaping (Result<String, Error>) -> Void) {
+    func requestPreAuthorizationCode(readOptions: ReadOptions?, completion: @escaping (Result<PreAuthResponse, Error>) -> Void) {
         guard let jwt = JWTUtility.preAuthorizationRequestJWT(configuration: configuration) else {
             fatalError("Invalid pre-authorization request JWT")
         }
@@ -89,6 +91,6 @@ struct JSONWebKeySet: Decodable {
     
     // Cache for 15 minutes
     var isValid: Bool {
-        Date() < date.addingTimeInterval(15*60)
+        Date() < date.addingTimeInterval(15 * 60)
     }
 }

--- a/Source/Authorization/OAuthToken.swift
+++ b/Source/Authorization/OAuthToken.swift
@@ -1,0 +1,16 @@
+//
+//  OAuthToken.swift
+//  DigiMeSDK
+//
+//  Created on 08/06/2021.
+//  Copyright © 2021 digi.me Limited. All rights reserved.
+//
+
+import Foundation
+
+struct OAuthToken {
+    let accessToken: String
+    let refreshToken: String
+    let expiry: Date
+    let tokenType: String?
+}

--- a/Source/Authorization/OAuthToken.swift
+++ b/Source/Authorization/OAuthToken.swift
@@ -8,9 +8,32 @@
 
 import Foundation
 
-struct OAuthToken {
-    let accessToken: String
-    let refreshToken: String
-    let expiry: Date
-    let tokenType: String?
+struct OAuthToken: Codable {
+    struct Token: Codable {
+        let expiry: Date
+        let value: String
+        
+        enum CodingKeys: String, CodingKey {
+            case expiry = "expires_on"
+            case value
+        }
+    }
+    
+    struct Identifier: Codable {
+        let id: String
+    }
+    
+    let accessToken: Token
+    let refreshToken: Token
+    let identifier: Identifier
+    let consentId: String
+    let tokenType: String
+    
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case refreshToken = "refresh_token"
+        case identifier
+        case consentId = "consentid"
+        case tokenType = "token_type"
+    }
 }

--- a/Source/CallbackService.swift
+++ b/Source/CallbackService.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+/// Handles callbacks via inter-app communication such as deeplinks
 public class CallbackService {
     
     /// The shared instance of the callback service.

--- a/Source/CallbackService.swift
+++ b/Source/CallbackService.swift
@@ -42,7 +42,7 @@ public class CallbackService {
             return false
         }
         
-        let parameters = urlComponents.queryItems?.reduce(into: [String: String]()) { result, item in
+        let parameters = urlComponents.queryItems?.reduce(into: [String: String?]()) { result, item in
             result[item.name] = item.value
         } ?? [:]
         
@@ -63,5 +63,5 @@ public class CallbackService {
 
 protocol CallbackHandler: AnyObject {
     func canHandleAction(_ action: String) -> Bool
-    func handleAction(_ action: String, with parameters: [String: String])
+    func handleAction(_ action: String, with parameters: [String: String?])
 }

--- a/Source/CallbackService.swift
+++ b/Source/CallbackService.swift
@@ -10,6 +10,10 @@ import Foundation
 
 public class CallbackService {
     
+    /// The shared instance of the callback service.
+    /// Handles communication to the SDK
+    ///
+    /// - Returns: A shared instance of `CallbackService`
     public class func shared() -> CallbackService {
         sharedService
     }
@@ -19,7 +23,13 @@ public class CallbackService {
     }()
     
     private weak var callbackHandler: CallbackHandler?
-
+    
+    /// Call this when app receives a callback that the SDK should handle
+    /// This should be called from either:
+    /// `func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool` or
+    /// `func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>)` if using scene delagtes
+    /// - Parameter url: The URL containing the callback
+    /// - Returns: `true` if the URL was handled by the SDK, `false` otherwise
     @discardableResult
     public func handleCallback(url: URL) -> Bool {
         guard url.absoluteString.hasPrefix("digime-ca-") else {

--- a/Source/CallbackService.swift
+++ b/Source/CallbackService.swift
@@ -1,0 +1,67 @@
+//
+//  CallbackService.swift
+//  DigiMeSDK
+//
+//  Created on 10/06/2021.
+//  Copyright © 2021 digi.me Limited. All rights reserved.
+//
+
+import Foundation
+
+public class CallbackService {
+    
+    public class func shared() -> CallbackService {
+        sharedService
+    }
+    
+    private static var sharedService: CallbackService = {
+        CallbackService()
+    }()
+    
+    private weak var callbackHandler: CallbackHandler?
+
+    @discardableResult
+    public func handleCallback(url: URL) -> Bool {
+        guard url.absoluteString.hasPrefix("digime-ca-") else {
+            return false
+        }
+        
+        guard let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            NSLog("Unable to parse callback url: \(url.absoluteString)")
+            return false
+        }
+        
+        guard let action = urlComponents.host else {
+            NSLog("Unable to extract callback action")
+            return false
+        }
+        
+        guard
+            let handler = callbackHandler,
+            handler.canHandleAction(action) else {
+            return false
+        }
+        
+        let parameters = urlComponents.queryItems?.reduce(into: [String: String]()) { result, item in
+            result[item.name] = item.value
+        } ?? [:]
+        
+        handler.handleAction(action, with: parameters)
+        return true
+    }
+    
+    func setCallbackHandler(_ handler: CallbackHandler) {
+        callbackHandler = handler
+    }
+    
+    func removeCallbackHandler(_ handler: CallbackHandler) {
+        if handler === callbackHandler {
+            callbackHandler = nil
+        }
+    }
+}
+
+protocol CallbackHandler: AnyObject {
+    func canHandleAction(_ action: String) -> Bool
+    func handleAction(_ action: String, with parameters: [String: String])
+}

--- a/Source/Configuration+Private.swift
+++ b/Source/Configuration+Private.swift
@@ -1,0 +1,20 @@
+//
+//  Configuration+Private.swift
+//  DigiMeSDK
+//
+//  Created on 08/06/2021.
+//  Copyright © 2021 digi.me Limited. All rights reserved.
+//
+
+import Foundation
+
+internal extension Configuration {
+    
+    var clientId: String {
+        "\(appId)_\(contractId)"
+    }
+    
+    var redirectUri: String {
+        "digime-ca-\(appId)"
+    }
+}

--- a/Source/Configuration+Private.swift
+++ b/Source/Configuration+Private.swift
@@ -15,6 +15,6 @@ internal extension Configuration {
     }
     
     var redirectUri: String {
-        "digime-ca-\(appId)"
+        "digime-ca-\(appId)://"
     }
 }

--- a/Source/Configuration.swift
+++ b/Source/Configuration.swift
@@ -17,12 +17,18 @@ public struct Configuration {
     /// Your contract identifier
     let contractId: String
     
-    /// Your PKCS1 private key - the bits between "-----BEGIN RSA PRIVATE KEY-----" and "-----END RSA PRIVATE KEY-----"
+    /// Your PKCS1 private key in PEM format - the bits between "-----BEGIN RSA PRIVATE KEY-----" and "-----END RSA PRIVATE KEY-----"
     let privateKey: String
     
-    /// Your PKCS1 public key - the bits between "-----BEGIN RSA PUBLIC KEY-----" and "-----END RSA PUBLIC KEY-----"
+    /// Your PKCS1 public key in PEM format - the bits between "-----BEGIN RSA PUBLIC KEY-----" and "-----END RSA PUBLIC KEY-----"
     let publicKey: String?
     
+    /// Creates a configuration
+    /// - Parameters:
+    ///   - appId: Your application identifier
+    ///   - contractId: Your contract identifier
+    ///   - privateKey: Your PKCS1 private key in PEM format
+    ///   - publicKey: Your PKCS1 public key in PEM format
     public init(appId: String, contractId: String, privateKey: String, publicKey: String? = nil) {
         self.appId = appId
         self.contractId = contractId

--- a/Source/Configuration.swift
+++ b/Source/Configuration.swift
@@ -17,9 +17,16 @@ public struct Configuration {
     /// Your contract identifier
     let contractId: String
     
-    /// Your PKCS1 private key
+    /// Your PKCS1 private key - the bits between "-----BEGIN RSA PRIVATE KEY-----" and "-----END RSA PRIVATE KEY-----"
     let privateKey: String
     
-    /// Your PKCS1 public key
+    /// Your PKCS1 public key - the bits between "-----BEGIN RSA PUBLIC KEY-----" and "-----END RSA PUBLIC KEY-----"
     let publicKey: String?
+    
+    public init(appId: String, contractId: String, privateKey: String, publicKey: String? = nil) {
+        self.appId = appId
+        self.contractId = contractId
+        self.privateKey = privateKey
+        self.publicKey = publicKey
+    }
 }

--- a/Source/Configuration.swift
+++ b/Source/Configuration.swift
@@ -1,0 +1,25 @@
+//
+//  Configuration.swift
+//  DigiMeSDK
+//
+//  Created on 08/06/2021.
+//  Copyright © 2021 digi.me Limited. All rights reserved.
+//
+
+import Foundation
+
+/// SDK Configuration
+public struct Configuration {
+    
+    /// Your application identifier
+    let appId: String
+    
+    /// Your contract identifier
+    let contractId: String
+    
+    /// Your PKCS1 private key
+    let privateKey: String
+    
+    /// Your PKCS1 public key
+    let publicKey: String?
+}

--- a/Source/DigiMeSDK.swift
+++ b/Source/DigiMeSDK.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+/// The entry point to the SDK
 public class DigiMeSDK {
     
     private let configuration: Configuration
@@ -16,10 +17,14 @@ public class DigiMeSDK {
     var service: OAuthService?
     var consentManager: ConsentManager?
     
+    /// Initialises a new instance of SDK.
+    /// A new instance should be created for each contract the app uses
+    /// - Parameter configuration: The configuration which defines this instance
     public init(configuration: Configuration) {
         self.configuration = configuration
     }
     
+    /// Blah blah - for dev purposes only
     public func testNewUser() {
         // During dev, this allows use to test flow inrementally
         let apiClient = APIClient()

--- a/Source/DigiMeSDK.swift
+++ b/Source/DigiMeSDK.swift
@@ -51,7 +51,7 @@ public class DigiMeSDK {
         }
     }
     
-    private func exchangeToken(authResponse: AuthResponse) {
+    private func exchangeToken(authResponse: ConsentResponse) {
         service?.requestTokenExchange(authCode: authResponse.authorizationCode) { result in
             do {
                 let response = try result.get()

--- a/Source/DigiMeSDK.swift
+++ b/Source/DigiMeSDK.swift
@@ -14,6 +14,7 @@ public class DigiMeSDK {
     
     // dev only?
     var service: OAuthService?
+    var consentManager: ConsentManager?
     
     public init(configuration: Configuration) {
         self.configuration = configuration
@@ -23,25 +24,27 @@ public class DigiMeSDK {
         // During dev, this allows use to test flow inrementally
         let apiClient = APIClient()
         service = OAuthService(configuration: configuration, apiClient: apiClient)
+        consentManager = ConsentManager(configuration: configuration)
         
         // Auth - needs app to be able to receive response via URL
         service!.requestPreAuthorizationCode(readOptions: nil) { result in
             if let response = try? result.get() {
-                var components = URLComponents(string: "https://api.development.devdigi.me/apps/saas/authorize")!
-                components.percentEncodedQueryItems = [
-                    .init(name: "code", value: response.token),
-                    .init(name: "errorCallback", value: "\(self.configuration.redirectUri)error".addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)),
-                    .init(name: "successCallback", value: "\(self.configuration.redirectUri)auth".addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)),
-                ]
-                let url = components.url!
-                DispatchQueue.main.async {
-                    UIApplication.shared.open(url, options: [:]) { success in
-                        let mce = 0
-                    }
-                }
+                self.peformAuth(preAuthResponse: response)
             }
         }
         
         let authCode = "862de8e4307f988164dee825008af37c1799597d60d755b2362e8a905070b7ac08a8e0dcb5e538377c66ba3c7326ce5a51d8bc71eca66a470301a3204ada425108eb5e9b5e131b1faa998e05a147424f"
+    }
+    
+    private func peformAuth(preAuthResponse: OAuthService.PreAuthResponse) {
+        consentManager?.requestUserConsent(preAuthCode: preAuthResponse.token, serviceId: nil) { result in
+            do {
+                let response = try result.get()
+                print(response)
+            }
+            catch {
+                print(error)
+            }
+        }
     }
 }

--- a/Source/DigiMeSDK.swift
+++ b/Source/DigiMeSDK.swift
@@ -12,11 +12,36 @@ public class DigiMeSDK {
     
     private let configuration: Configuration
     
+    // dev only?
+    var service: OAuthService?
+    
     public init(configuration: Configuration) {
         self.configuration = configuration
     }
     
     public func testNewUser() {
         // During dev, this allows use to test flow inrementally
+        let apiClient = APIClient()
+        service = OAuthService(configuration: configuration, apiClient: apiClient)
+        
+        // Auth - needs app to be able to receive response via URL
+        service!.requestPreAuthorizationCode(readOptions: nil) { result in
+            if let response = try? result.get() {
+                var components = URLComponents(string: "https://api.development.devdigi.me/apps/saas/authorize")!
+                components.percentEncodedQueryItems = [
+                    .init(name: "code", value: response.token),
+                    .init(name: "errorCallback", value: "\(self.configuration.redirectUri)error".addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)),
+                    .init(name: "successCallback", value: "\(self.configuration.redirectUri)auth".addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)),
+                ]
+                let url = components.url!
+                DispatchQueue.main.async {
+                    UIApplication.shared.open(url, options: [:]) { success in
+                        let mce = 0
+                    }
+                }
+            }
+        }
+        
+        let authCode = "862de8e4307f988164dee825008af37c1799597d60d755b2362e8a905070b7ac08a8e0dcb5e538377c66ba3c7326ce5a51d8bc71eca66a470301a3204ada425108eb5e9b5e131b1faa998e05a147424f"
     }
 }

--- a/Source/DigiMeSDK.swift
+++ b/Source/DigiMeSDK.swift
@@ -27,19 +27,30 @@ public class DigiMeSDK {
         consentManager = ConsentManager(configuration: configuration)
         
         // Auth - needs app to be able to receive response via URL
-        service!.requestPreAuthorizationCode(readOptions: nil) { result in
+        service?.requestPreAuthorizationCode(readOptions: nil) { result in
             if let response = try? result.get() {
                 self.peformAuth(preAuthResponse: response)
             }
         }
-        
-        let authCode = "862de8e4307f988164dee825008af37c1799597d60d755b2362e8a905070b7ac08a8e0dcb5e538377c66ba3c7326ce5a51d8bc71eca66a470301a3204ada425108eb5e9b5e131b1faa998e05a147424f"
     }
     
     private func peformAuth(preAuthResponse: OAuthService.PreAuthResponse) {
         consentManager?.requestUserConsent(preAuthCode: preAuthResponse.token, serviceId: nil) { result in
             do {
                 let response = try result.get()
+                self.exchangeToken(authResponse: response)
+            }
+            catch {
+                print(error)
+            }
+        }
+    }
+    
+    private func exchangeToken(authResponse: AuthResponse) {
+        service?.requestTokenExchange(authCode: authResponse.authorizationCode) { result in
+            do {
+                let response = try result.get()
+    
                 print(response)
             }
             catch {

--- a/Source/Error/AuthError.swift
+++ b/Source/Error/AuthError.swift
@@ -1,0 +1,19 @@
+//
+//  AuthError.swift
+//  DigiMeSDK
+//
+//  Created on 11/06/2021.
+//  Copyright © 2021 digi.me Limited. All rights reserved.
+//
+
+import Foundation
+
+enum AuthError: String, Error {
+    case initializeCheckFailed = "INITIALIZE_CHECK_FAIL"
+    case userCancelled = "USER_CANCEL"
+    case serviceOnboardError = "ONBOARD_ERROR"
+    case invalidCode = "INVALID_CODE"
+    case serverError = "SERVER_ERROR"
+    
+    case unexpectedError
+}

--- a/Source/Error/ConsentError.swift
+++ b/Source/Error/ConsentError.swift
@@ -1,5 +1,5 @@
 //
-//  AuthError.swift
+//  ConsentError.swift
 //  DigiMeSDK
 //
 //  Created on 11/06/2021.
@@ -8,7 +8,7 @@
 
 import Foundation
 
-enum AuthError: String, Error {
+enum ConsentError: String, Error {
     case initializeCheckFailed = "INITIALIZE_CHECK_FAIL"
     case userCancelled = "USER_CANCEL"
     case serviceOnboardError = "ONBOARD_ERROR"

--- a/Source/Network/APIClient.swift
+++ b/Source/Network/APIClient.swift
@@ -10,6 +10,7 @@ import Foundation
 
 enum HTTPError: Error {
     case noResponse
+    case noData
     case unsuccesfulStatusCode(Int, response: ErrorResponse?)
 }
 
@@ -39,12 +40,12 @@ class APIClient {
         return URLSession(configuration: configuration)
     }()
     
-    private lazy var agent: Agent = {
+    lazy var agent: Agent = {
         let version = Bundle(for: Self.self).object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
         return Agent(name: "ios", version: version)
     }()
 
-    func makeRequest<T: Decodable>(_ router: NetworkRouter, completion: @escaping (Result<T?, Error>) -> Void) {
+    func makeRequest<T: Decodable>(_ router: NetworkRouter, completion: @escaping (Result<T, Error>) -> Void) {
         guard let request = try? router.asURLRequest() else {
             return
         }
@@ -80,7 +81,7 @@ class APIClient {
             }
             
             guard let data = data else {
-                completion(.success(nil))
+                completion(.failure(HTTPError.noData))
                 return
             }
             

--- a/Source/Network/APIClient.swift
+++ b/Source/Network/APIClient.swift
@@ -1,0 +1,111 @@
+//
+//  APIClient.swift
+//  DigiMeSDK
+//
+//  Created on 07/06/2021.
+//  Copyright © 2021 digi.me Limited. All rights reserved.
+//
+
+import Foundation
+
+enum HTTPError: Error {
+    case noResponse
+    case unsuccesfulStatusCode(Int, response: ErrorResponse?)
+}
+
+struct ErrorResponse: Decodable {
+    struct Recovery: Decodable {
+        let validAt: TimeInterval
+    }
+    
+    let code: String
+    let message: String
+    let recovery: Recovery?
+}
+
+struct ErrorWrapper: Decodable {
+    let error: ErrorResponse
+}
+
+class APIClient {
+    
+    private lazy var session: URLSession = {
+        let configuration = URLSessionConfiguration.default
+        configuration.httpAdditionalHeaders = [
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        ]
+        
+        return URLSession(configuration: configuration)
+    }()
+    
+    private lazy var agent: Agent = {
+        let version = Bundle(for: Self.self).object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
+        return Agent(name: "ios", version: version)
+    }()
+
+    func makeRequest<T: Decodable>(_ router: NetworkRouter, completion: @escaping (Result<T?, Error>) -> Void) {
+        guard let request = try? router.asURLRequest() else {
+            return
+        }
+        
+        session.dataTask(with: request) { data, response, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+            
+            guard let httpResonse = response as? HTTPURLResponse else {
+                completion(.failure(HTTPError.noResponse))
+                return
+            }
+            
+            self.logStatusMessage(from: httpResonse)
+            
+            guard (200..<300).contains(httpResonse.statusCode) else {
+                var errorWrapper: ErrorWrapper?
+                if let data = data {
+                    errorWrapper = try? data.decoded()
+                }
+                
+                if let errorResponse = errorWrapper?.error {
+                    NSLog("Request: \(request.url?.absoluteString ?? "") failed with status code: \(httpResonse.statusCode), error code: \(errorResponse.code), message: \(errorResponse.message)")
+                }
+                else {
+                    NSLog("Request: \(request.url?.absoluteString ?? "") failed with status code: \(httpResonse.statusCode)")
+                }
+                
+                completion(.failure(HTTPError.unsuccesfulStatusCode(httpResonse.statusCode, response: errorWrapper?.error)))
+                return
+            }
+            
+            guard let data = data else {
+                completion(.success(nil))
+                return
+            }
+            
+            do {
+                let result = try data.decoded() as T
+                completion(.success(result))
+            }
+            catch {
+                completion(.failure(error))
+            }
+        }.resume()
+    }
+    
+    private func preflight() {
+        
+    }
+    
+    private func logStatusMessage(from response: HTTPURLResponse) {
+        let headers = response.allHeaderFields
+        guard
+            let status = headers["x-digi-sdk-status"],
+            let message = headers["x-digi-sdk-status-message"] else {
+            return
+        }
+        
+        NSLog("\n===========================================================\nSDK Status: \(status)\n\(message)\n===========================================================")
+    }
+}

--- a/Source/Network/Agent.swift
+++ b/Source/Network/Agent.swift
@@ -3,7 +3,7 @@
 //  DigiMeSDK
 //
 //  Created on 06/06/2021.
-//  Copyright © 2021 diig.me Limited. All rights reserved.
+//  Copyright © 2021 digi.me Limited. All rights reserved.
 //
 
 import Foundation

--- a/Source/Network/Duration.swift
+++ b/Source/Network/Duration.swift
@@ -3,7 +3,7 @@
 //  DigiMeSDK
 //
 //  Created on 06/06/2021.
-//  Copyright © 2021 diig.me Limited. All rights reserved.
+//  Copyright © 2021 digi.me Limited. All rights reserved.
 //
 
 import Foundation

--- a/Source/Network/JSONRequestBody.swift
+++ b/Source/Network/JSONRequestBody.swift
@@ -17,6 +17,6 @@ struct JSONRequestBody: RequestBody {
     }
     
     init<T: Encodable>(parameters: T) throws {
-        data = try JSONEncoder().encode(parameters)
+        data = try parameters.encoded()
     }
 }

--- a/Source/Network/JSONRequestBody.swift
+++ b/Source/Network/JSONRequestBody.swift
@@ -3,7 +3,7 @@
 //  DigiMeSDK
 //
 //  Created on 04/06/2021.
-//  Copyright © 2021 diig.me Limited. All rights reserved.
+//  Copyright © 2021 digi.me Limited. All rights reserved.
 //
 
 import Foundation

--- a/Source/Network/Limits.swift
+++ b/Source/Network/Limits.swift
@@ -3,7 +3,7 @@
 //  DigiMeSDK
 //
 //  Created on 06/06/2021.
-//  Copyright © 2021 diig.me Limited. All rights reserved.
+//  Copyright © 2021 digi.me Limited. All rights reserved.
 //
 
 import Foundation

--- a/Source/Network/MultipartFormRequestBody.swift
+++ b/Source/Network/MultipartFormRequestBody.swift
@@ -3,7 +3,7 @@
 //  DigiMeSDK
 //
 //  Created on 04/06/2021.
-//  Copyright © 2021 diig.me Limited. All rights reserved.
+//  Copyright © 2021 digi.me Limited. All rights reserved.
 //
 
 import Foundation

--- a/Source/Network/NetworkRouter.swift
+++ b/Source/Network/NetworkRouter.swift
@@ -14,6 +14,7 @@ enum NetworkRouter {
     case trigger(jwt: String, agent: Agent?, readOptions: ReadOptions?)
     case read(sessionKey: String, fileId: String? = nil)
     case write(postboxId: String, payload: Data, jwt: String)
+    case jwks
     
     private struct AuthorizeBody: Encodable {
         struct Actions: Encodable {
@@ -62,7 +63,7 @@ enum NetworkRouter {
         case .authorize, .tokenExchange, .trigger, .write:
             return "POST"
             
-        case .read:
+        case .read, .jwks:
             return "GET"
         }
     }
@@ -88,12 +89,15 @@ enum NetworkRouter {
             
         case .write(let postboxId, _, _):
             return "/permission-access/postbox/\(postboxId)"
+            
+        case .jwks:
+            return "/jwks/oauth"
         }
     }
     
     private var body: RequestBody? {
         switch self {
-        case .tokenExchange, .read:
+        case .tokenExchange, .read, .jwks:
             return nil
             
         case let .authorize(_, agent, readOptions):
@@ -127,7 +131,7 @@ enum NetworkRouter {
              .write(_, _, let token):
             return token
             
-        case .read:
+        case .read, .jwks:
             return nil
         }
     }

--- a/Source/Network/ReadAccept.swift
+++ b/Source/Network/ReadAccept.swift
@@ -3,7 +3,7 @@
 //  DigiMeSDK
 //
 //  Created on 04/06/2021.
-//  Copyright © 2021 diig.me Limited. All rights reserved.
+//  Copyright © 2021 digi.me Limited. All rights reserved.
 //
 
 import Foundation

--- a/Source/Network/ReadOptions.swift
+++ b/Source/Network/ReadOptions.swift
@@ -3,7 +3,7 @@
 //  DigiMeSDK
 //
 //  Created on 06/06/2021.
-//  Copyright © 2021 diig.me Limited. All rights reserved.
+//  Copyright © 2021 digi.me Limited. All rights reserved.
 //
 
 import Foundation

--- a/Source/Network/RequestBody.swift
+++ b/Source/Network/RequestBody.swift
@@ -3,7 +3,7 @@
 //  DigiMeSDK
 //
 //  Created on 04/06/2021.
-//  Copyright © 2021 diig.me Limited. All rights reserved.
+//  Copyright © 2021 digi.me Limited. All rights reserved.
 //
 
 import Foundation

--- a/Source/Network/Scope.swift
+++ b/Source/Network/Scope.swift
@@ -3,7 +3,7 @@
 //  DigiMeSDK
 //
 //  Created on 06/06/2021.
-//  Copyright © 2021 diig.me Limited. All rights reserved.
+//  Copyright © 2021 digi.me Limited. All rights reserved.
 //
 
 import Foundation

--- a/Source/Network/ServiceGroup.swift
+++ b/Source/Network/ServiceGroup.swift
@@ -3,7 +3,7 @@
 //  DigiMeSDK
 //
 //  Created on 06/06/2021.
-//  Copyright © 2021 diig.me Limited. All rights reserved.
+//  Copyright © 2021 digi.me Limited. All rights reserved.
 //
 
 import Foundation

--- a/Source/Network/ServiceObjectType.swift
+++ b/Source/Network/ServiceObjectType.swift
@@ -3,7 +3,7 @@
 //  DigiMeSDK
 //
 //  Created on 06/06/2021.
-//  Copyright © 2021 diig.me Limited. All rights reserved.
+//  Copyright © 2021 digi.me Limited. All rights reserved.
 //
 
 import Foundation

--- a/Source/Network/ServiceType.swift
+++ b/Source/Network/ServiceType.swift
@@ -3,7 +3,7 @@
 //  DigiMeSDK
 //
 //  Created on 06/06/2021.
-//  Copyright © 2021 diig.me Limited. All rights reserved.
+//  Copyright © 2021 digi.me Limited. All rights reserved.
 //
 
 import Foundation

--- a/Source/Network/TimeRange.swift
+++ b/Source/Network/TimeRange.swift
@@ -3,7 +3,7 @@
 //  DigiMeSDK
 //
 //  Created on 06/06/2021.
-//  Copyright © 2021 diig.me Limited. All rights reserved.
+//  Copyright © 2021 digi.me Limited. All rights reserved.
 //
 
 import Foundation

--- a/Source/Network/URLRequestConvertible.swift
+++ b/Source/Network/URLRequestConvertible.swift
@@ -3,7 +3,7 @@
 //  DigiMeSDK
 //
 //  Created on 04/06/2021.
-//  Copyright © 2021 diig.me Limited. All rights reserved.
+//  Copyright © 2021 digi.me Limited. All rights reserved.
 //
 
 import Foundation

--- a/Source/Utilities/Codable+Logging.swift
+++ b/Source/Utilities/Codable+Logging.swift
@@ -1,0 +1,83 @@
+//
+//  Codable+Logging.swift
+//  DigiMeSDK
+//
+//  Created on 08/06/2021.
+//  Copyright © 2021 digi.me Limited. All rights reserved.
+//
+
+import Foundation
+
+extension Encodable {
+    func encoded() throws -> Data {
+        do {
+            return try JSONEncoder().encode(self)
+        }
+        catch {
+            if let error = (error as? EncodingError) {
+                switch error {
+                case .invalidValue(_, let context):
+                    NSLog("Error encoding `\(context.codingPath.compactMap { $0.stringValue }.joined(separator: "."))` in \(String(describing: self)): \(context.debugDescription)")
+                default:
+                    NSLog("Error encoding \(String(describing: self)): \(error.localizedDescription)")
+                }
+            }
+            else {
+                NSLog("Error encoding \(String(describing: self)): \(error.localizedDescription)")
+            }
+            
+            throw error
+        }
+    }
+    
+    var dictionary: Any? {
+        guard let data = try? encoded() else {
+            return nil
+        }
+        
+        return (try? JSONSerialization.jsonObject(with: data, options: .allowFragments))
+    }
+}
+
+extension Data {
+    func decoded<T: Decodable>() throws -> T {
+        do {
+            return try JSONDecoder().decode(T.self, from: self)
+        }
+        catch {
+            if let error = (error as? DecodingError) {
+                switch error {
+                case .keyNotFound(_, let context):
+                    NSLog("Error decoding `\(context.codingPath.compactMap { $0.stringValue }.joined(separator: "."))` in \(String(describing: T.self)): \(context.debugDescription)")
+                case .typeMismatch(_, let context):
+                    NSLog("Error decoding `\(context.codingPath.compactMap { $0.stringValue }.joined(separator: "."))` in \(String(describing: T.self)): \(context.debugDescription)")
+                case .valueNotFound(_, let context):
+                    NSLog("Error decoding `\(context.codingPath.compactMap { $0.stringValue }.joined(separator: "."))` in \(String(describing: T.self)): \(context.debugDescription)")
+                case .dataCorrupted(let context):
+                    NSLog("Error decoding `\(context.codingPath.compactMap { $0.stringValue }.joined(separator: "."))` in \(String(describing: T.self)): \(context.debugDescription)")
+                default:
+                    NSLog("Error decoding \(String(describing: T.self)): \(error.localizedDescription)")
+                }
+            }
+            else {
+                NSLog("Error decoding \(String(describing: T.self)): \(error.localizedDescription)")
+            }
+            
+            throw error
+        }
+    }
+}
+
+extension Dictionary {
+    func decoded<T: Decodable>() throws -> T {
+        let data = try JSONSerialization.data(withJSONObject: self, options: [])
+        return try data.decoded()
+    }
+}
+
+extension Array {
+    func decoded<T: Decodable>() throws -> T {
+        let data = try JSONSerialization.data(withJSONObject: self, options: [])
+        return try data.decoded()
+    }
+}

--- a/Source/Utilities/Data+Base64.swift
+++ b/Source/Utilities/Data+Base64.swift
@@ -1,0 +1,19 @@
+//
+//  Data+Base64.swift
+//  DigiMeSDK
+//
+//  Created on 10/01/2020.
+//  Copyright © 2019 digi.me Limited. All rights reserved.
+//
+
+import Foundation
+
+extension Data {
+    init?(base64URLEncoded string: String) {
+        self.init(base64Encoded: string.base64())
+    }
+
+    func base64URLEncodedString() -> String {
+        return self.base64EncodedString().base64Url()
+    }
+}

--- a/Source/Utilities/String+Base64.swift
+++ b/Source/Utilities/String+Base64.swift
@@ -1,0 +1,35 @@
+//
+//  String+Base64.swift
+//  DigiMeSDK
+//
+//  Created on 10/01/2020.
+//  Copyright © 2019 digi.me Limited. All rights reserved.
+//
+
+import Foundation
+
+extension String {
+    
+    func isBase64() -> Bool {
+        let chars = CharacterSet(charactersIn: "0123456789ABCDEF")
+        guard uppercased().rangeOfCharacter(from: chars) != nil else {
+           return false
+        }
+        return true
+    }
+    
+    func base64() -> String {
+        var base64 = self.replacingOccurrences(of: "_", with: "/").replacingOccurrences(of: "-", with: "+")
+        if !base64.count.isMultiple(of: 4) {
+            base64.append(String(repeating: "=", count: 4 - base64.count % 4))
+        }
+        return base64
+    }
+
+    func base64Url() -> String {
+        let base64url = self.replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "=", with: "")
+        return base64url
+    }
+}

--- a/Source/Utilities/UIViewController+TopMost.swift
+++ b/Source/Utilities/UIViewController+TopMost.swift
@@ -1,0 +1,32 @@
+//
+//  UIViewController+TopMost.swift
+//  DigiMeSDK
+//
+//  Created on 11/06/2021.
+//  Copyright © 2021 digi.me Limited. All rights reserved.
+//
+
+import Foundation
+
+extension UIViewController {
+    
+    class func topMostViewController() -> UIViewController? {
+        UIApplication.shared.windows.first { $0.isKeyWindow }?.rootViewController?.topMostViewController()
+    }
+    
+    func topMostViewController() -> UIViewController {
+        if let presentedViewController = presentedViewController {
+            return presentedViewController.topMostViewController()
+        }
+        
+        if let navigationController = self as? UINavigationController {
+            return navigationController.visibleViewController?.topMostViewController() ?? navigationController
+        }
+        
+        if let tabBarController = self as? UITabBarController {
+            return tabBarController.selectedViewController?.topMostViewController() ?? tabBarController
+        }
+        
+        return self
+    }
+}


### PR DESCRIPTION
There is already a lot here, so I may have missed something!

Notable exceptions to code are preflight and error handling.

A fair few classes are in existing SDK and have either been converted from Objc to Swift or have just been refactored.

There are also elements of SDK-5 (onboarding logic) and SDK-9 (authorisation helpers) contained as these were needed to be able to test the api calls.